### PR TITLE
Fix data class error caused by python 3.11

### DIFF
--- a/scoreperformer/experiments/trainer_config.py
+++ b/scoreperformer/experiments/trainer_config.py
@@ -158,7 +158,7 @@ class TrainerConfig(Config):
     )
 
     optimization: OptimizerConfig = field(
-        default=OptimizerConfig(
+        default_factory=lambda: OptimizerConfig(
             lr=1e-3,
             optimizer="adam",
             optimizer_params={"weight_decay": 1e-6},

--- a/scoreperformer/models/scoreperformer/mmd_transformer.py
+++ b/scoreperformer/models/scoreperformer/mmd_transformer.py
@@ -62,8 +62,8 @@ class MMDTupleTransformer(TupleTransformer):
             num_tokens: Dict[str, int],
             dim: int = 512,
             max_seq_len: int = 1024,
-            transformer: Union[DictConfig, TransformerConfig] = TransformerConfig(_target_="default"),
-            token_embeddings: Union[DictConfig, TupleTokenEmbeddingsConfig] = TupleTokenEmbeddingsConfig(),
+            transformer: Union[DictConfig, TransformerConfig] = None,
+            token_embeddings: Union[DictConfig, TupleTokenEmbeddingsConfig] = None,
             use_abs_pos_emb: bool = True,
             emb_norm: bool = False,
             emb_dropout: float = 0.0,
@@ -84,6 +84,10 @@ class MMDTupleTransformer(TupleTransformer):
             deadpan_zero_latent: bool = False,  # optimize latents to zero for deadpan performances
             loss_weight: float = 1.0
     ):
+        if transformer is None:
+            transformer = TransformerConfig(_target_="default")
+        if token_embeddings is None:
+            token_embeddings = TupleTokenEmbeddingsConfig()
         super().__init__(
             num_tokens=num_tokens,
             dim=dim,

--- a/scoreperformer/models/scoreperformer/transformer.py
+++ b/scoreperformer/models/scoreperformer/transformer.py
@@ -1,6 +1,6 @@
 """ TupleTransformer: Transformer with support for tuple token sequences. """
 
-from dataclasses import dataclass, MISSING
+from dataclasses import dataclass, MISSING, field
 from typing import Optional, Union, Dict, List
 
 import torch
@@ -48,9 +48,11 @@ class TupleTransformerConfig(ModuleConfig):
     num_tokens: Dict[str, int] = MISSING
     dim: int = 512
     max_seq_len: int = 1024
-    transformer: Union[DictConfig, TransformerConfig] = TransformerConfig(_target_="default")
+    transformer: Union[DictConfig, TransformerConfig] = field(
+        default_factory=lambda: TransformerConfig(_target_="default"))
 
-    token_embeddings: Union[DictConfig, TupleTokenEmbeddingsConfig] = TupleTokenEmbeddingsConfig()
+    token_embeddings: Union[DictConfig, TupleTokenEmbeddingsConfig] = field(
+        default_factory=TupleTokenEmbeddingsConfig)
     use_abs_pos_emb: bool = True
     emb_norm: bool = False
     emb_dropout: float = 0.0

--- a/scoreperformer/modules/transformer/transformer.py
+++ b/scoreperformer/modules/transformer/transformer.py
@@ -5,7 +5,7 @@ Adapted from: https://github.com/lucidrains/x-transformers
 """
 
 import copy
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from functools import partial
 from typing import Optional, Union, List
 
@@ -39,8 +39,8 @@ class TransformerConfig(VariableModuleConfig):
     depth: int = 4
     heads: int = 8
 
-    attention: Union[AttentionConfig, DictConfig] = AttentionConfig()
-    feed_forward: Union[FeedForwardConfig, DictConfig] = FeedForwardConfig()
+    attention: Union[AttentionConfig, DictConfig] = None
+    feed_forward: Union[FeedForwardConfig, DictConfig] = None
 
     causal: bool = False
     cross_attend: bool = False
@@ -58,8 +58,8 @@ class Transformer(nn.Module, Constructor):
             dim: int = 512,
             depth: int = 4,
             heads: int = 8,
-            attention: Union[AttentionConfig, DictConfig] = AttentionConfig(),
-            feed_forward: Union[FeedForwardConfig, DictConfig] = FeedForwardConfig(),
+            attention: Union[AttentionConfig, DictConfig] = None,
+            feed_forward: Union[FeedForwardConfig, DictConfig] = None,
             causal: bool = False,
             cross_attend: bool = False,
             only_cross: bool = False,
@@ -68,6 +68,9 @@ class Transformer(nn.Module, Constructor):
             style_emb_dim: Optional[int] = None
     ):
         super().__init__()
+
+        attention = attention if attention else AttentionConfig()
+        feed_forward = feed_forward if feed_forward else FeedForwardConfig()
 
         self.dim = dim
         self.depth = depth


### PR DESCRIPTION
Due to this [change](https://docs.python.org/3.11/whatsnew/3.11.html#dataclasses) in python 3.11, the Google Colab demo will fail since Colab's python version was recently [upgraded](https://github.com/googlecolab/colabtools/issues/4935) to 3.11

This pull request fixed this problem and was tested on Google Colab.

Thanks for this amazing repo!